### PR TITLE
Check if input_memory exists

### DIFF
--- a/griptape/tools/tool_output_processor/tool.py
+++ b/griptape/tools/tool_output_processor/tool.py
@@ -118,4 +118,7 @@ class ToolOutputProcessor(BaseTool):
             return ErrorArtifact("memory not found")
 
     def find_input_memory(self, memory_id: str) -> Optional[TextToolMemory]:
-        return next((m for m in self.input_memory if isinstance(m, TextToolMemory) and m.id == memory_id), None)
+        if self.input_memory:
+            return next((m for m in self.input_memory if isinstance(m, TextToolMemory) and m.id == memory_id), None)
+        else:
+            return None


### PR DESCRIPTION
`input_memory` is optional, and must be checked before finding.